### PR TITLE
Fix studio TypeScript config and path aliases

### DIFF
--- a/apps/simulator-studio/env.d.ts
+++ b/apps/simulator-studio/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/simulator-studio/tsconfig.json
+++ b/apps/simulator-studio/tsconfig.json
@@ -1,16 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    },
-    "jsx": "preserve",
-    "strict": true,
-    "types": ["vite/client"]
+    }
   },
-  "include": ["src/**/*", "index.html"]
+  "include": ["src", "env.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.4.0",
+    "@types/node": "^20",
+    "typescript": "^5",
     "vite": "^5.2.8",
     "vitest": "^1.6.0",
-    "vue-tsc": "^1.8.27"
+    "vue-tsc": "^2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "useDefineForClassFields": true,
+    "resolveJsonModule": true,
+    "types": ["vite/client", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@studio/*": ["apps/simulator-studio/src/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist", ".mockdb"]
+}


### PR DESCRIPTION
## Summary
- add repo-level `tsconfig.json` with shared aliases for root and Studio
- scope Studio `tsconfig` to local `src` and include Vite env types
- declare missing dev tooling deps in `package.json`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npm run admin:dev` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_689fd29eb2408323863365e81f2049ce