### PR TITLE
Simplify studio dev server setup

### DIFF
--- a/apps/simulator-studio/vite.config.ts
+++ b/apps/simulator-studio/vite.config.ts
@@ -6,14 +6,15 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig(() => {
-  const studioPort = Number(process.env.STUDIO_PORT) || 5199
+  const studioPort = Number(process.env.STUDIO_PORT) || 3000
 
   return {
     root: 'apps/simulator-studio',
     plugins: [vue()],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, 'src')
+        '@': path.resolve(__dirname, 'src'),
+        '@studio': path.resolve(__dirname, 'src')
       }
     },
     server: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:e2e": "vite --host 127.0.0.1 --strictPort --mode e2e --config apps/main-app/vite.config.ts",
     "preview:e2e": "vite build --mode e2e --config apps/main-app/vite.config.ts && vite preview --host 127.0.0.1 --strictPort --config apps/main-app/vite.config.ts",
     "mock:dev": "cross-env NODE_ENV=development node apps/mock-backend/server.js",
-    "admin:dev": "cross-env NODE_ENV=development vite --config apps/simulator-studio/vite.config.ts --port %STUDIO_PORT%",
+    "admin:dev": "cross-env NODE_ENV=development vite --config apps/simulator-studio/vite.config.ts",
     "admin:build": "vite build --config apps/simulator-studio/vite.config.ts",
     "admin:preview": "vite preview --config apps/simulator-studio/vite.config.ts",
     "typecheck": "vue-tsc --noEmit",


### PR DESCRIPTION
## Summary
- add `@studio` alias and default dev port
- drop undefined `%STUDIO_PORT%` flag from admin dev script

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36ac61568832394d0e38892fa6a56