### PR TITLE
Default studio port and load root env

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ This repository contains the complete front‑end and mock API server for the **
 
 1. Скопируйте переменные окружения: `cp .env.example .env` (Windows: `copy .env.example .env`).
 2. Установите зависимости: `npm install`.
-3. Подготовьте демо-данные: `npm run seed:clean && npm run seed:demo`.
-4. Запустите все сервисы:
-   - macOS/Linux: `APP_PORT=5173 STUDIO_PORT=5199 npm run dev:all`
-   - Windows (CMD/PowerShell): `npm run dev:all`
+3. (Optional) reset demo data / (Опционально) сбросьте демо-данные: `npm run seed:clean && npm run seed:demo`.
+   Mock backend auto-seeds default users / Мок-бэкенд автоматически создаёт демо-учётки.
+4. Запустите все сервисы: `npm run dev:all`
 5. Откройте в браузере:
    - Main app — http://localhost:5173/
-   - Simulator Studio — http://localhost:5199/login
+   - Simulator Studio — http://localhost:3000/
    - Mock backend — http://localhost:3001/
 
 6. Войдите одной из демо‑учёток:

--- a/apps/mock-backend/server.js
+++ b/apps/mock-backend/server.js
@@ -17,7 +17,6 @@ require('dotenv').config();
 
 export const app = express();
 const MOCK_PORT = Number(process.env.MOCK_PORT) || 3001;
-const STUDIO_PORT = Number(process.env.STUDIO_PORT) || 5199;
 const ADMIN_KEY = process.env.VITE_ADMIN_KEY || 'dev-admin-key';
 const JWT_SECRET = process.env.MOCK_JWT_SECRET || 'dev-secret-please-change';
 const { json } = require('express');
@@ -31,7 +30,10 @@ function buildUserIndex() {
   }
 }
 
-// seeds are triggered via scripts; just build index on start
+// seed demo data on first run so default credentials work out of the box
+if (db.users.length === 0) {
+  seedDemo(db);
+}
 buildUserIndex();
 
 app.use(cors({ origin: [/^http:\/\/localhost:\d+$/], credentials: true }));

--- a/apps/simulator-studio/vite.config.ts
+++ b/apps/simulator-studio/vite.config.ts
@@ -6,14 +6,16 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig(() => {
-  const studioPort = Number(process.env.STUDIO_PORT) || 5199
+  const studioPort = Number(process.env.STUDIO_PORT) || 3000
 
   return {
     root: 'apps/simulator-studio',
+    envDir: path.resolve(__dirname, '../..'),
     plugins: [vue()],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, 'src')
+        '@': path.resolve(__dirname, 'src'),
+        '@studio': path.resolve(__dirname, 'src')
       }
     },
     server: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:e2e": "vite --host 127.0.0.1 --strictPort --mode e2e --config apps/main-app/vite.config.ts",
     "preview:e2e": "vite build --mode e2e --config apps/main-app/vite.config.ts && vite preview --host 127.0.0.1 --strictPort --config apps/main-app/vite.config.ts",
     "mock:dev": "cross-env NODE_ENV=development node apps/mock-backend/server.js",
-    "admin:dev": "cross-env NODE_ENV=development vite --config apps/simulator-studio/vite.config.ts --port %STUDIO_PORT%",
+    "admin:dev": "cross-env NODE_ENV=development vite --config apps/simulator-studio/vite.config.ts",
     "admin:build": "vite build --config apps/simulator-studio/vite.config.ts",
     "admin:preview": "vite preview --config apps/simulator-studio/vite.config.ts",
     "typecheck": "vue-tsc --noEmit",

--- a/tests/studio-smoke.spec.ts
+++ b/tests/studio-smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const base = `http://localhost:${process.env.STUDIO_PORT || '5199'}`;
+const base = `http://localhost:${process.env.STUDIO_PORT || '3000'}`;
 
 async function login(page, email: string) {
   await page.goto(`${base}/#/login`);


### PR DESCRIPTION
## Summary
- load `.env` from repo root for simulator studio
- drop `STUDIO_PORT` flag and update docs and tests for port 3000

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36ac61568832394d0e38892fa6a56