### PR TITLE
Add mock tenant selector login

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@ Simulator Studio in [`apps/simulator-studio/`](../apps/simulator-studio/) browse
 | [src/views/PricingView.vue](../src/views/PricingView.vue) | Upgrade plans |
 | [src/views/DashboardView.vue](../src/views/DashboardView.vue) | Placeholder dashboard |
 | [src/views/NotFoundView.vue](../src/views/NotFoundView.vue) | 404 page |
+| [src/views/LoginView.vue](../src/views/LoginView.vue) | Mock tenant selector login |
 
 ### Components
 | File | Purpose |
@@ -157,6 +158,7 @@ Simulator Studio in [`apps/simulator-studio/`](../apps/simulator-studio/) browse
 | `POST /chats/:id/unsnooze` | Unsnooze chat |
 | `GET /agents` | List agents |
 | `GET /operators` | List operators |
+| `GET /tenants` | List tenants for mock login |
 | `GET /knowledge*` | Knowledge collections and sources |
 | `POST /account/upgrade` | Upgrade pricing plan |
 `mock_backend/db.json` seeds the data and `mock_backend/server.js` serves the endpoints.

--- a/docs/CHANGELOG_HEAD.md
+++ b/docs/CHANGELOG_HEAD.md
@@ -2,6 +2,10 @@
 
 Use this section to draft release notes for the next version. Copy relevant entries into `CHANGELOG.md` when releasing.
 
+## Authentication
+
+- Mock tenant selector login in main app
+
 ## Presence stacks
 
 - Show stacked avatars for chat participants and polling improvements

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -3,6 +3,7 @@
 | Feature | Main files | Stores | API endpoints | Tests |
 | --- | --- | --- | --- | --- |
 | Status colors | [src/utils/statusTheme.js](../src/utils/statusTheme.js) | – | – | – |
+| Mock tenant login | [src/views/LoginView.vue](../src/views/LoginView.vue) | [src/stores/authStore.ts](../src/stores/authStore.ts) | `GET /tenants` | [mock_backend/tests/tenants.spec.ts](../mock_backend/tests/tenants.spec.ts) |
 | Grouping/filters | [src/views/ChatsView.vue](../src/views/ChatsView.vue), [src/views/chatsUtils.js](../src/views/chatsUtils.js) | [src/stores/chatStore.js](../src/stores/chatStore.js) | `GET /chats` | [src/views/__tests__/ChatsView.search.test.js](../src/views/__tests__/ChatsView.search.test.js) |
 | Presence stacks | [src/views/ChatWindow.vue](../src/views/ChatWindow.vue), [src/views/ChatsView.vue](../src/views/ChatsView.vue), [src/components/StackedAvatars.vue](../src/components/StackedAvatars.vue) | [src/stores/presenceStore.js](../src/stores/presenceStore.js) | `POST /presence/list`, `POST /presence/join`, `POST /presence/leave` | [e2e/presence.spec.ts](../e2e/presence.spec.ts), [src/stores/__tests__/presenceStore.test.js](../src/stores/__tests__/presenceStore.test.js) |
 | Tiny agent avatar | [src/components/AgentBadge.vue](../src/components/AgentBadge.vue), [src/views/ChatsView.vue](../src/views/ChatsView.vue) | [src/stores/agentStore.js](../src/stores/agentStore.js) | `GET /agents` | [src/views/__tests__/ChatsView.agentBadge.test.js](../src/views/__tests__/ChatsView.agentBadge.test.js) |

--- a/mock_backend/server.js
+++ b/mock_backend/server.js
@@ -171,6 +171,13 @@ const { ensureScopes } = require('./utils/db');
 const writeDb = (data) => fs.writeFileSync(dbPath, JSON.stringify(data, null, 2));
 
 
+// Tenants listing for mock login
+app.get('/tenants', (_req, res) => {
+  const db = readDb();
+  const list = (db.tenants || []).map(t => ({ id: t.id, name: t.name }));
+  res.json(list);
+});
+
 // AUTH
 
 app.post('/api/auth/login', (req, res) => {

--- a/mock_backend/tests/tenants.spec.ts
+++ b/mock_backend/tests/tenants.spec.ts
@@ -1,0 +1,25 @@
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+
+let server: any;
+const BASE = 'http://localhost:3100';
+
+beforeAll(async () => {
+  server = (await import('../server.js')).default;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('GET /tenants', () => {
+  it('returns tenants with id and name', async () => {
+    const res = await fetch(`${BASE}/tenants`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    for (const t of data) {
+      expect(t).toHaveProperty('id');
+      expect(t).toHaveProperty('name');
+    }
+  });
+});

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,40 +1,38 @@
 <template>
   <div class="max-w-sm mx-auto mt-20 space-y-4">
-    <h2 class="text-xl font-semibold">Login / Вход</h2>
-    <form @submit.prevent="submit" class="space-y-2">
-      <input v-model="email" placeholder="Email / Эл. почта" class="w-full p-2 rounded bg-slate-700" />
-      <input type="password" v-model="password" placeholder="Password / Пароль" class="w-full p-2 rounded bg-slate-700" />
-      <button type="submit" class="w-full py-2 bg-blue-600 text-white rounded">Login / Войти</button>
-    </form>
-    <p v-if="error" class="text-red-400">{{ error }}</p>
-    <router-link to="/login?skipAuth=1" class="underline text-sm">Skip / Без входа</router-link>
-    <div class="text-xs text-slate-400">
-      Demo accounts / Демо-аккаунты:<br />
-      alpha@raw.dev / RawDev!2025<br />
-      alpha.op@raw.dev / RawDev!2025<br />
-      beta@raw.dev / RawDev!2025
-    </div>
+    <h2 class="text-xl font-semibold">Select tenant / Выберите тенанта</h2>
+    <select v-model="selectedTenant" class="w-full p-2 rounded bg-slate-700">
+      <option disabled value="">Select… / Выберите…</option>
+      <option v-for="t in tenants" :key="t.id" :value="t">{{ t.name }}</option>
+    </select>
+    <button
+      class="w-full py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+      :disabled="!selectedTenant"
+      @click="login"
+    >
+      Login / Войти
+    </button>
   </div>
 </template>
 
-<script setup>
-import { ref } from 'vue';
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from '@/stores/authStore';
 
-const email = ref('');
-const password = ref('');
-const error = ref('');
+const tenants = ref<Array<any>>([]);
+const selectedTenant = ref<any | null>(null);
 const router = useRouter();
 const auth = useAuthStore();
 
-async function submit() {
-  error.value = '';
-  try {
-    await auth.login(email.value, password.value);
-    router.push({ name: 'dashboard' });
-  } catch {
-    error.value = 'Invalid credentials / Неверные данные';
-  }
+onMounted(async () => {
+  const res = await fetch('/tenants');
+  tenants.value = await res.json();
+});
+
+function login() {
+  if (!selectedTenant.value) return;
+  auth.setSession('mock-token', { id: 'mock', name: 'Mock User' }, [selectedTenant.value], selectedTenant.value.id);
+  router.push({ name: 'dashboard' });
 }
 </script>


### PR DESCRIPTION
## Summary
- replace password form with tenant selector for mock logins
- route `/login` to the new selector view
- document tenant selector login and `/tenants` endpoint

## Testing
- `npm install` (fails: 403 Forbidden for @playwright/test)
- `npm test` (fails: vitest not found)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68a81feb26888323922c4455b13cc9bc