### PR TITLE
Prefix tenants route with /api

### DIFF
--- a/mock_backend/server.js
+++ b/mock_backend/server.js
@@ -172,7 +172,7 @@ const writeDb = (data) => fs.writeFileSync(dbPath, JSON.stringify(data, null, 2)
 
 
 // Tenants listing for mock login
-app.get('/tenants', (_req, res) => {
+app.get('/api/tenants', (_req, res) => {
   const db = readDb();
   const list = (db.tenants || []).map(t => ({ id: t.id, name: t.name }));
   res.json(list);

--- a/mock_backend/tests/tenants.spec.ts
+++ b/mock_backend/tests/tenants.spec.ts
@@ -11,9 +11,9 @@ afterAll(() => {
   server.close();
 });
 
-describe('GET /tenants', () => {
+describe('GET /api/tenants', () => {
   it('returns tenants with id and name', async () => {
-    const res = await fetch(`${BASE}/tenants`);
+    const res = await fetch(`${BASE}/api/tenants`);
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(Array.isArray(data)).toBe(true);

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -26,7 +26,7 @@ const router = useRouter();
 const auth = useAuthStore();
 
 onMounted(async () => {
-  const res = await fetch('/tenants');
+  const res = await fetch('/api/tenants');
   tenants.value = await res.json();
 });
 


### PR DESCRIPTION
## Summary
- prefix `/tenants` route with `/api` for tenant listing
- update backend test to hit `/api/tenants`
- fetch tenants from `/api/tenants` in login view

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8285368ec8323bafb12303f6f84fb