### PR TITLE
Add tenants API route

### DIFF
--- a/apps/mock-backend/server.js
+++ b/apps/mock-backend/server.js
@@ -39,6 +39,11 @@ app.use(cors({ origin: [/^http:\/\/localhost:\d+$/], credentials: true }));
 
 app.use(json({ limit: '5mb' }));
 
+app.get('/api/tenants', (_req, res) => {
+  const list = db.tenants.map((t) => ({ id: t.slug, name: t.name }));
+  res.json(list);
+});
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 app.use('/avatars', express.static(path.join(__dirname, 'public/avatars')));
 app.use('/files', express.static(path.resolve('.mockdb/files')));


### PR DESCRIPTION
## Summary
- expose tenants list via /api/tenants

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npm run mock:dev` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82cc9e8e483238026c676ddde23bc